### PR TITLE
Query string deserialization: Allow multiple values for one key

### DIFF
--- a/src/urlencoded/de/val_or_vec.rs
+++ b/src/urlencoded/de/val_or_vec.rs
@@ -15,7 +15,7 @@ pub enum ValOrVec<T> {
 impl<T> ValOrVec<T> {
     pub fn push(&mut self, new_val: T) {
         match self {
-            Self::Val(val) => {
+            ValOrVec::Val(val) => {
                 let mut vec = Vec::with_capacity(2);
                 // Safety:
                 //
@@ -25,10 +25,10 @@ impl<T> ValOrVec<T> {
                     let existing_val = ptr::read(val);
                     vec.push(existing_val);
                     vec.push(new_val);
-                    ptr::write(self, Self::Vec(vec))
+                    ptr::write(self, ValOrVec::Vec(vec))
                 }
             }
-            Self::Vec(vec) => vec.push(new_val),
+            ValOrVec::Vec(vec) => vec.push(new_val),
         }
     }
 }
@@ -50,8 +50,8 @@ pub enum IntoIter<T> {
 impl<T> IntoIter<T> {
     fn new(vv: ValOrVec<T>) -> Self {
         match vv {
-            ValOrVec::Val(val) => Self::Val(iter::once(val)),
-            ValOrVec::Vec(vec) => Self::Vec(vec.into_iter()),
+            ValOrVec::Val(val) => IntoIter::Val(iter::once(val)),
+            ValOrVec::Vec(vec) => IntoIter::Vec(vec.into_iter()),
         }
     }
 }
@@ -61,8 +61,8 @@ impl<T> Iterator for IntoIter<T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::Val(iter) => iter.next(),
-            Self::Vec(iter) => iter.next(),
+            IntoIter::Val(iter) => iter.next(),
+            IntoIter::Vec(iter) => iter.next(),
         }
     }
 }
@@ -85,8 +85,8 @@ macro_rules! forward_to_part {
                 where V: de::Visitor<'de>
             {
                 match self {
-                    Self::Val(val) => val.$method(visitor),
-                    Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+                    ValOrVec::Val(val) => val.$method(visitor),
+                    ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
                 }
             }
         )*
@@ -104,8 +104,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_any(visitor),
-            Self::Vec(_) => self.deserialize_seq(visitor),
+            ValOrVec::Val(val) => val.deserialize_any(visitor),
+            ValOrVec::Vec(_) => self.deserialize_seq(visitor),
         }
     }
 
@@ -126,8 +126,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_enum(name, variants, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => val.deserialize_enum(name, variants, visitor),
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 
@@ -140,8 +140,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_tuple(len, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => val.deserialize_tuple(len, visitor),
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 
@@ -155,8 +155,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_struct(name, fields, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => val.deserialize_struct(name, fields, visitor),
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 
@@ -169,8 +169,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_unit_struct(name, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => val.deserialize_unit_struct(name, visitor),
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 
@@ -184,8 +184,10 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_tuple_struct(name, len, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => {
+                val.deserialize_tuple_struct(name, len, visitor)
+            }
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 
@@ -198,8 +200,8 @@ where
         V: de::Visitor<'de>,
     {
         match self {
-            Self::Val(val) => val.deserialize_newtype_struct(name, visitor),
-            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Val(val) => val.deserialize_newtype_struct(name, visitor),
+            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
         }
     }
 

--- a/src/urlencoded/de/val_or_vec.rs
+++ b/src/urlencoded/de/val_or_vec.rs
@@ -234,3 +234,31 @@ where
         deserialize_map,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use matches::assert_matches;
+
+    use super::ValOrVec;
+
+    #[test]
+    fn cow_borrowed() {
+        let mut x = ValOrVec::Val(Cow::Borrowed("a"));
+        x.push(Cow::Borrowed("b"));
+        x.push(Cow::Borrowed("c"));
+        assert_matches!(x, ValOrVec::Vec(v) if v == vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn cow_owned() {
+        let mut x = ValOrVec::Val(Cow::from("a".to_owned()));
+        x.push(Cow::from("b".to_owned()));
+        x.push(Cow::from("c".to_owned()));
+        assert_matches!(
+            x,
+            ValOrVec::Vec(v) if v == vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+        );
+    }
+}

--- a/src/urlencoded/de/val_or_vec.rs
+++ b/src/urlencoded/de/val_or_vec.rs
@@ -1,0 +1,229 @@
+use std::{iter, ptr, vec};
+
+use serde::de::{
+    self,
+    value::{Error, SeqDeserializer},
+    Deserializer, IntoDeserializer,
+};
+
+#[derive(Debug)]
+pub enum ValOrVec<T> {
+    Val(T),
+    Vec(Vec<T>),
+}
+
+impl<T> ValOrVec<T> {
+    pub fn push(&mut self, new_val: T) {
+        match self {
+            Self::Val(val) => {
+                let mut vec = Vec::with_capacity(2);
+                // Safety:
+                //
+                // since the vec is pre-allocated, push can't panic, so there
+                // is no opportunity for a panic in the unsafe code.
+                unsafe {
+                    let existing_val = ptr::read(val);
+                    vec.push(existing_val);
+                    vec.push(new_val);
+                    ptr::write(self, Self::Vec(vec))
+                }
+            }
+            Self::Vec(vec) => vec.push(new_val),
+        }
+    }
+}
+
+impl<T> IntoIterator for ValOrVec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
+    }
+}
+
+pub enum IntoIter<T> {
+    Val(iter::Once<T>),
+    Vec(vec::IntoIter<T>),
+}
+
+impl<T> IntoIter<T> {
+    fn new(vv: ValOrVec<T>) -> Self {
+        match vv {
+            ValOrVec::Val(val) => Self::Val(iter::once(val)),
+            ValOrVec::Vec(vec) => Self::Vec(vec.into_iter()),
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Val(iter) => iter.next(),
+            Self::Vec(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'de, T> IntoDeserializer<'de> for ValOrVec<T>
+where
+    T: IntoDeserializer<'de> + Deserializer<'de, Error = Error>,
+{
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+macro_rules! forward_to_part {
+    ($($method:ident,)*) => {
+        $(
+            fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+                where V: de::Visitor<'de>
+            {
+                match self {
+                    Self::Val(val) => val.$method(visitor),
+                    Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+                }
+            }
+        )*
+    }
+}
+
+impl<'de, T> Deserializer<'de> for ValOrVec<T>
+where
+    T: IntoDeserializer<'de> + Deserializer<'de, Error = Error>,
+{
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_any(visitor),
+            Self::Vec(_) => self.deserialize_seq(visitor),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_seq(SeqDeserializer::new(self.into_iter()))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_enum(name, variants, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    fn deserialize_tuple<V>(
+        self,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_tuple(len, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_struct(name, fields, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_unit_struct(name, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_tuple_struct(name, len, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Self::Val(val) => val.deserialize_newtype_struct(name, visitor),
+            Self::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+        }
+    }
+
+    forward_to_part! {
+        deserialize_bool,
+        deserialize_char,
+        deserialize_str,
+        deserialize_string,
+        deserialize_bytes,
+        deserialize_byte_buf,
+        deserialize_unit,
+        deserialize_u8,
+        deserialize_u16,
+        deserialize_u32,
+        deserialize_u64,
+        deserialize_i8,
+        deserialize_i16,
+        deserialize_i32,
+        deserialize_i64,
+        deserialize_f32,
+        deserialize_f64,
+        deserialize_option,
+        deserialize_identifier,
+        deserialize_ignored_any,
+        deserialize_map,
+    }
+}

--- a/src/urlencoded/de/val_or_vec.rs
+++ b/src/urlencoded/de/val_or_vec.rs
@@ -91,7 +91,7 @@ macro_rules! forward_to_part {
             {
                 match self {
                     ValOrVec::Val(val) => val.$method(visitor),
-                    ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+                    ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
                 }
             }
         )*
@@ -132,7 +132,7 @@ where
     {
         match self {
             ValOrVec::Val(val) => val.deserialize_enum(name, variants, visitor),
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 
@@ -146,7 +146,7 @@ where
     {
         match self {
             ValOrVec::Val(val) => val.deserialize_tuple(len, visitor),
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 
@@ -161,7 +161,7 @@ where
     {
         match self {
             ValOrVec::Val(val) => val.deserialize_struct(name, fields, visitor),
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 
@@ -175,7 +175,7 @@ where
     {
         match self {
             ValOrVec::Val(val) => val.deserialize_unit_struct(name, visitor),
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 
@@ -192,7 +192,7 @@ where
             ValOrVec::Val(val) => {
                 val.deserialize_tuple_struct(name, len, visitor)
             }
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 
@@ -206,7 +206,7 @@ where
     {
         match self {
             ValOrVec::Val(val) => val.deserialize_newtype_struct(name, visitor),
-            ValOrVec::Vec(_) => Err(de::Error::custom("TODO: Error message")),
+            ValOrVec::Vec(_) => Err(de::Error::custom("unsupported value")),
         }
     }
 

--- a/tests/url_deserialize.rs
+++ b/tests/url_deserialize.rs
@@ -69,13 +69,13 @@ enum X {
 
 #[test]
 fn deserialize_unit_enum() {
-    let result = vec![
-        ("one".to_owned(), X::A),
-        ("two".to_owned(), X::B),
-        ("three".to_owned(), X::C),
-    ];
+    let result: Vec<(String, X)> =
+        urlencoded::from_str("one=A&two=B&three=C").unwrap();
 
-    assert_eq!(urlencoded::from_str("one=A&two=B&three=C"), Ok(result));
+    assert_eq!(result.len(), 3);
+    assert!(result.contains(&("one".to_owned(), X::A)));
+    assert!(result.contains(&("two".to_owned(), X::B)));
+    assert!(result.contains(&("three".to_owned(), X::C)));
 }
 
 #[test]
@@ -129,7 +129,6 @@ struct ListStruct {
 }
 
 #[test]
-#[ignore]
 fn deserialize_newstruct() {
     let de = NewStruct {
         list: vec!["hello", "world"],
@@ -138,7 +137,6 @@ fn deserialize_newstruct() {
 }
 
 #[test]
-#[ignore]
 fn deserialize_numlist() {
     let de = NumList {
         list: vec![1, 2, 3, 4],
@@ -147,7 +145,6 @@ fn deserialize_numlist() {
 }
 
 #[test]
-#[ignore]
 fn deserialize_vec_bool() {
     assert_eq!(
         urlencoded::from_str("item=true&item=false&item=false"),
@@ -158,7 +155,6 @@ fn deserialize_vec_bool() {
 }
 
 #[test]
-#[ignore]
 fn deserialize_vec_string() {
     assert_eq!(
         urlencoded::from_str("item=hello&item=matrix&item=hello"),
@@ -173,7 +169,6 @@ fn deserialize_vec_string() {
 }
 
 #[test]
-#[ignore]
 fn deserialize_struct_unit_enum() {
     let result = Wrapper {
         item: vec![X::A, X::B, X::C],


### PR DESCRIPTION
Still to do:

* [x] Test use of `unsafe` with miri
  * [x] Add more tests for `ValOrVec` and make sure those pass too
* [x] Fix `TODO: Error message`s
* [x] Update tests
* [x] Fix building on Rust 1.36